### PR TITLE
Update helpers.ts for Lattice1 Hardware Wallet Support

### DIFF
--- a/src/api/helpers.ts
+++ b/src/api/helpers.ts
@@ -702,7 +702,7 @@ const APP_NAME = "Bancor Swap";
 
 const wallets = [
   { walletName: "metamask", preferred: true },
-  { walletName: "lattice", appName: "Bancor Swap", rpcUrl: infuraRpc, preferred: true },
+  { walletName: "lattice", appName: "Bancor Swap", rpcUrl: RPC_URL, preferred: true },
   { walletName: "imToken", rpcUrl: RPC_URL, preferred: true },
   { walletName: "coinbase" },
   { walletName: "trust", rpcUrl: RPC_URL, preferred: true },

--- a/src/api/helpers.ts
+++ b/src/api/helpers.ts
@@ -702,6 +702,7 @@ const APP_NAME = "Bancor Swap";
 
 const wallets = [
   { walletName: "metamask", preferred: true },
+  { walletName: "lattice", appName: "Bancor Swap", rpcUrl: infuraRpc, preferred: true },
   { walletName: "imToken", rpcUrl: RPC_URL, preferred: true },
   { walletName: "coinbase" },
   { walletName: "trust", rpcUrl: RPC_URL, preferred: true },


### PR DESCRIPTION
**Background**
The Lattice1 is GridPlus' next generation hardware wallet. It is an always-online device with physically separated compute environments which provide unmatched security. For more information, see https://gridplus.io/lattice

**About this PR**
This PR adds the Lattice1 as a wallet option for bnc-notify. The Lattice1 is supported in v1.14.0 which currently used by Bancor Swap.

Note that a (nearly) identical integration was added to Curve. [That pull request](https://github.com/curvefi/curve-vue/pull/6) has several photos documenting what it is like to connect to and use an app with the Lattice1 and bnc-notify.

Thanks and please let us know if you have any questions!