### PR TITLE
Add jest config for mocking api/helpers

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,17 +3,6 @@ module.exports = {
   automock: false,
   setupFiles: ["./setupJest.js"],
 
-  // preset: "@vue/cli-plugin-unit-jest",
-  // moduleFileExtensions: ["js", "ts", "json", "vue", "node"],
-  // transform: {
-  //   '^.+\\.vue$': 'vue-jest',
-  //   '.+\\.(css|styl|less|sass|scss|png|jpg|ttf|woff|woff2)$':
-  //     'jest-transform-stub',
-  //   "^.+\\.(ts|tsx)$": "ts-jest",
-  //   "^.+\\.js$": "babel-jest"
-  // },
-  // transformIgnorePatterns: ['node_modules']
-
   moduleNameMapper: {
     "/api/helper(.*)": "<rootDir>/tests/unit/__mocks__/helpersMock.ts"
   },

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,7 +14,11 @@ module.exports = {
   // },
   // transformIgnorePatterns: ['node_modules']
 
+  moduleNameMapper: {
+    "/api/helper(.*)": "<rootDir>/tests/unit/__mocks__/helpersMock.ts"
+  },
+
   transformIgnorePatterns: [
-    "/node_modules/(?!(eos-transit-lynx-provider|eos-transit-ledger-provider))"
+    "/node_modules/(?!(eos-transit-lynx-provider|eos-transit-ledger-provider))"    
   ]
 };

--- a/src/api/helpers.ts
+++ b/src/api/helpers.ts
@@ -176,24 +176,6 @@ export const formatNumber = (num: number | string, size: number = 4) => {
   return reduced;
 };
 
-export const prettifyNumber = (
-  num: number | string | BigNumber,
-  usd = false
-): string => {
-  const bigNum = new BigNumber(num);
-  if (usd) {
-    if (bigNum.lte(0)) return "$0.00";
-    else if (bigNum.lt(0.01)) return "< $0.01";
-    else if (bigNum.gt(100)) return numeral(bigNum).format("$0,0");
-    else return numeral(bigNum).format("$0,0.00");
-  } else {
-    if (bigNum.lte(0)) return "0";
-    else if (bigNum.gte(2)) return numeral(bigNum).format("0,0.[00]");
-    else if (bigNum.lt(0.000001)) return "< 0.000001";
-    else return numeral(bigNum).format("0.[000000]");
-  }
-};
-
 export const stringifyPercentage = (percentage: number): string => {
   if (percentage <= 0) return "0.00%";
   else if (percentage < 0.0001) return "< 0.01%";

--- a/src/api/pureHelpers.ts
+++ b/src/api/pureHelpers.ts
@@ -240,54 +240,72 @@ export const calculatePriceDeviationTooHigh = (
   return priceDeviationTooHigh;
 };
 
-export const prettifyNumber = (num: number | string, usd = false): string => {
-  const roundDown = (num: number, places: number): number => {
-    const string = num.toString();
-    const number = string.split(".")[0];
-    const decimals = string.split(".")[1];
-    if (!decimals || !places) return Number(number);
-    else {
-      const result = number + "." + decimals.substr(0, places);
-      return Number(result);
-    }
-  };
-
-  const addCommaSeparator = (num: number, per = 3) => {
-    const string = num.toString();
-    const number = string.split(".")[0];
-    const decimal = string.split(".")[1];
-    let aComma = "";
-    if (number.length > per) {
-      let j = 0;
-      for (let i = number.length - 1; i >= 0; i--) {
-        aComma = number.charAt(i) + aComma;
-        j++;
-        if (j == per && i != 0) {
-          aComma = "," + aComma;
-          j = 0;
-        }
-      }
-    } else {
-      aComma = number;
-    }
-    return aComma + (decimal ? `.${decimal}` : "");
-  };
-
-  const number = Number(num);
-  if (isNaN(number)) return "N/A";
-
-  let result = 0;
+export const prettifyNumber = (
+  num: number | string | BigNumber,
+  usd = false
+): string => {
+  const bigNum = new BigNumber(num);
   if (usd) {
-    if (number === 0) return "$0";
-    else if (number < 0.01) return "< $0.01";
-    else if (number >= 100) result = Number(number.toFixed(0));
-    else result = Number(number.toFixed(2));
-    return "$" + addCommaSeparator(result);
+    if (bigNum.lte(0)) return "$0.00";
+    else if (bigNum.lt(0.01)) return "< $0.01";
+    else if (bigNum.gt(100)) return numeral(bigNum).format("$0,0");
+    else return numeral(bigNum).format("$0,0.00");
   } else {
-    if (number === 0) return "0";
-    else if (number < 0.000001) return "< 0.000001";
-    else if (number >= 2) result = Number(number.toFixed(2));
-    else result = Number(number.toFixed(6));
-    return addCommaSeparator(result);
+    if (bigNum.lte(0)) return "0";
+    else if (bigNum.gte(2)) return numeral(bigNum).format("0,0.[00]");
+    else if (bigNum.lt(0.000001)) return "< 0.000001";
+    else return numeral(bigNum).format("0.[000000]");
   }
 };
+
+// export const prettifyNumber = (num: number | string, usd = false): string => {
+//   const roundDown = (num: number, places: number): number => {
+//     const string = num.toString();
+//     const number = string.split(".")[0];
+//     const decimals = string.split(".")[1];
+//     if (!decimals || !places) return Number(number);
+//     else {
+//       const result = number + "." + decimals.substr(0, places);
+//       return Number(result);
+//     }
+//   };
+//
+//   const addCommaSeparator = (num: number, per = 3) => {
+//     const string = num.toString();
+//     const number = string.split(".")[0];
+//     const decimal = string.split(".")[1];
+//     let aComma = "";
+//     if (number.length > per) {
+//       let j = 0;
+//       for (let i = number.length - 1; i >= 0; i--) {
+//         aComma = number.charAt(i) + aComma;
+//         j++;
+//         if (j == per && i != 0) {
+//           aComma = "," + aComma;
+//           j = 0;
+//         }
+//       }
+//     } else {
+//       aComma = number;
+//     }
+//     return aComma + (decimal ? `.${decimal}` : "");
+//   };
+//
+//   const number = Number(num);
+//   if (isNaN(number)) return "N/A";
+//
+//   let result = 0;
+//   if (usd) {
+//     if (number === 0) return "$0";
+//     else if (number < 0.01) return "< $0.01";
+//     else if (number >= 100) result = Number(number.toFixed(0));
+//     else result = Number(number.toFixed(2));
+//     return "$" + addCommaSeparator(result);
+//   } else {
+//     if (number === 0) return "0";
+//     else if (number < 0.000001) return "< 0.000001";
+//     else if (number >= 2) result = Number(number.toFixed(2));
+//     else result = Number(number.toFixed(6));
+//     return addCommaSeparator(result);
+//   }
+// };

--- a/src/components/BaseComponent.vue
+++ b/src/components/BaseComponent.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { Component, Vue } from "vue-property-decorator";
 import { State, Getter } from "vuex-class";
-import { prettifyNumber } from "@/api/helpers";
+import { prettifyNumber } from "@/api/pureHelpers";
 
 @Component
 export default class BaseComponent extends Vue {

--- a/tests/unit/__mocks__/helpersMock.ts
+++ b/tests/unit/__mocks__/helpersMock.ts
@@ -1,0 +1,5 @@
+
+
+export const prettifyNumber = (): string => {
+  return ""
+}

--- a/tests/unit/pureHelpers.spec.ts
+++ b/tests/unit/pureHelpers.spec.ts
@@ -590,7 +590,7 @@ describe("Prettify Numbers", () => {
 
     const resultNumbers: string[] = numbers.map(n => prettifyNumber(n, true));
     const expectedNumbers: string[] = [
-      "$0",
+      "$0.00",
       "< $0.01",
       "$1.12",
       "$1.10",
@@ -619,7 +619,7 @@ describe("Prettify Numbers", () => {
       prettifyNumber(n, true)
     );
     const expectedNumbers: string[] = [
-      "$0",
+      "$0.00",
       "< $0.01",
       "$1.12",
       "$1.10",


### PR DESCRIPTION
- Add jest config for mocking current `api/helpers.ts`, which is linked to `tests/unit/__mocks__/helpersMock.ts`
- Recommend you move `prettifyNumber` in `helpers.ts` to in `pureHelpers.ts`. The functions that do not import other libraries, such as vxm, need to be isolated in `pureHelpers.ts`.
