### PR TITLE
generate pool name once, not over and over on render

### DIFF
--- a/src/api/helpers.ts
+++ b/src/api/helpers.ts
@@ -18,7 +18,8 @@ import {
   ViewAmount,
   ViewRelay,
   ViewToken,
-  TableItem
+  TableItem,
+  ViewReserve
 } from "@/types/bancor";
 import Web3 from "web3";
 import { EosTransitModule } from "@/store/modules/wallet/eosWallet";
@@ -1236,14 +1237,20 @@ export const getCountryCode = async (): Promise<string> => {
 };
 
 export const buildPoolName = (
-  poolId: string,
-  separator: string = "/"
+  poolId: string
 ): string => {
   const pool: ViewRelay = vxm.bancor.relay(poolId);
-  if (pool) {
-    const symbols = pool.reserves.map(x => x.symbol);
-    return symbols.reverse().join(separator);
+  if(pool) {
+    return buildPoolNameFromReserves(pool.reserves);
   } else return "N/A";
+};
+
+export const buildPoolNameFromReserves = (
+  reserves: ViewReserve[],
+  separator: string = "/"
+): string => {
+    const symbols = reserves.map(x => x.symbol);
+    return symbols.reverse().join(separator);
 };
 
 export const formatUnixTime = (

--- a/src/components/common/PoolLogos.vue
+++ b/src/components/common/PoolLogos.vue
@@ -34,7 +34,6 @@
 import { Component, Prop, Emit } from "vue-property-decorator";
 import { ViewRelay, ViewToken } from "@/types/bancor";
 import PoolLogosOverlapped from "@/components/common/PoolLogosOverlapped.vue";
-import { buildPoolName } from "@/api/helpers";
 import VersionBadge from "@/components/common/VersionBadge.vue";
 import BaseComponent from "@/components/BaseComponent.vue";
 
@@ -53,12 +52,7 @@ export default class PoolLogos extends BaseComponent {
   click() {}
 
   get baseLabel() {
-    return `${this.label ? `${this.label} ` : ""}${this.poolName}`;
-  }
-
-  get poolName() {
-    if (this.pool && this.pool.id) return buildPoolName(this.pool.id);
-    else return "N/A";
+    return `${this.label ? `${this.label} ` : ""}${this.pool?.name || "N/A"}`;
   }
 }
 </script>

--- a/src/components/data/details/DataDetailsPool.vue
+++ b/src/components/data/details/DataDetailsPool.vue
@@ -7,7 +7,7 @@
           class="font-size-20 font-w600 mt-3 d-flex align-items-center"
           :class="[darkMode ? 'text-dark' : 'text-light']"
         >
-          <span class="mr-2">{{ poolName }} Pool</span>
+          <span class="mr-2">{{ pool.name }} Pool</span>
           <version-badge :version="poolVersion" />
         </div>
       </b-col>
@@ -44,7 +44,7 @@
 
         <content-block title="Pool Information" :shadow-light="true">
           <div class="my-3">
-            <label-content-split label="Pool Name" :value="poolName" />
+            <label-content-split label="Pool Name" :value="pool.name" />
             <label-content-split
               label="Pool Address"
               :value="shortAddress"
@@ -101,7 +101,7 @@ import LabelContentSplit from "@/components/common/LabelContentSplit.vue";
 import StatisticsDataBlock from "@/components/data/statistics/StatisticsDataBlock.vue";
 import TransactionTables from "@/components/data/transactiontables/TransactionTables.vue";
 import MainButton from "@/components/common/Button.vue";
-import { buildPoolName, formatNumber, shortenEthAddress } from "@/api/helpers";
+import { formatNumber, shortenEthAddress } from "@/api/helpers";
 import PoolLogosOverlapped from "@/components/common/PoolLogosOverlapped.vue";
 import VersionBadge from "@/components/common/VersionBadge.vue";
 import numeral from "numeral";
@@ -170,10 +170,6 @@ export default class DataPool extends BaseComponent {
 
   get transactions() {
     return "????????";
-  }
-
-  get poolName() {
-    return buildPoolName(this.pool.id);
   }
 
   get totalPoolWeight() {

--- a/src/components/protection/AddProtectionDouble.vue
+++ b/src/components/protection/AddProtectionDouble.vue
@@ -42,7 +42,7 @@
             class="font-size-24 font-w600"
             :class="darkMode ? 'text-dark' : 'text-light'"
           >
-            {{ `${formatNumber(amount)} ${poolName}` }}
+            {{ `${formatNumber(amount)} ${pool.name}` }}
           </span>
         </b-col>
         <b-col v-if="false" cols="12">
@@ -85,7 +85,6 @@ import {
   compareString,
   formatUnixTime,
   formatNumber,
-  buildPoolName
 } from "@/api/helpers";
 import MainButton from "@/components/common/Button.vue";
 import AlertBlock from "@/components/common/AlertBlock.vue";
@@ -125,10 +124,6 @@ export default class AddProtectionDouble extends BaseComponent {
 
   get pools() {
     return vxm.bancor.relays.filter(x => x.liquidityProtection);
-  }
-
-  get poolName() {
-    return buildPoolName(this.pool.id);
   }
 
   get balance() {

--- a/src/components/protection/AddProtectionSingle.vue
+++ b/src/components/protection/AddProtectionSingle.vue
@@ -109,7 +109,7 @@ import TokenInputField from "@/components/common/TokenInputField.vue";
 import BigNumber from "bignumber.js";
 import GrayBorderBlock from "@/components/common/GrayBorderBlock.vue";
 import LabelContentSplit from "@/components/common/LabelContentSplit.vue";
-import { formatUnixTime, formatNumber, buildPoolName } from "@/api/helpers";
+import { formatUnixTime, formatNumber } from "@/api/helpers";
 import MainButton from "@/components/common/Button.vue";
 import AlertBlock from "@/components/common/AlertBlock.vue";
 import ModalBase from "@/components/modals/ModalBase.vue";
@@ -191,10 +191,6 @@ export default class AddProtectionSingle extends BaseComponent {
 
   get pools() {
     return vxm.bancor.relays.filter(x => x.whitelisted);
-  }
-
-  get poolName() {
-    return buildPoolName(this.pool.id);
   }
 
   get isWhitelisted() {

--- a/src/store/modules/swap/eosBancor.ts
+++ b/src/store/modules/swap/eosBancor.ts
@@ -30,7 +30,8 @@ import {
   TxResponse,
   DFuseTrade,
   ViewTradeEvent,
-  ViewLiquidityEvent
+  ViewLiquidityEvent,
+  ViewReserve
 } from "@/types/bancor";
 import { bancorApi, ethBancorApi } from "@/api/bancorApiWrapper";
 import {
@@ -53,7 +54,8 @@ import {
   assetToDecNumberString,
   decNumberStringToAsset,
   findChangedReserve,
-  StringPool
+  StringPool,
+  buildPoolNameFromReserves
 } from "@/api/helpers";
 import {
   Sym as Symbol,
@@ -636,8 +638,7 @@ export class EosBancorModule
   }
 
   get currentUser() {
-    // @ts-ignore
-    return this.$store.rootGetters[`${this.wallet}Wallet/currentUser`];
+    return vxm.wallet.currentUser
   }
 
   @action async onAuthChange(currentUser: string | false) {
@@ -1131,6 +1132,14 @@ export class EosBancorModule
           reserve => reserve.symbol
         );
 
+        const reserves = sortedReserves.map((reserve: AgnosticToken) => ({
+          ...reserve,
+          reserveWeight: 0.5,
+          reserveId: relay.id + reserve.id,
+          logo: [this.token(reserve.id).logo],
+          ...(reserve.amount && { balance: reserve.amount })
+        } as ViewReserve))
+
         return {
           ...relay,
           version: relay.isMultiContract ? 2 : 1,
@@ -1138,6 +1147,7 @@ export class EosBancorModule
             contract: relay.smartToken.contract,
             symbol: relay.smartToken.symbol
           }),
+          name: buildPoolNameFromReserves(reserves),
           symbol: sortedReserves[1].symbol,
           liqDepth: relayFeed && relayFeed.liqDepth,
           addLiquiditySupported: relay.isMultiContract,
@@ -1146,14 +1156,8 @@ export class EosBancorModule
           v2: false,
           liquidityProtection: false,
           whitelisted: false,
-          reserves: sortedReserves.map((reserve: AgnosticToken) => ({
-            ...reserve,
-            reserveWeight: 0.5,
-            reserveId: relay.id + reserve.id,
-            logo: [this.token(reserve.id).logo],
-            ...(reserve.amount && { balance: reserve.amount })
-          }))
-        };
+          reserves
+        } as ViewRelay;
       });
   }
 
@@ -1851,7 +1855,7 @@ export class EosBancorModule
             if (failedDueToBadCalculation) {
               const { fundAmount, addLiquidityActions } = state;
               const backupFundAction = multiContractAction.fund(
-                vxm.wallet.currentUser,
+                this.currentUser,
                 number_to_asset(
                   Number(fundAmount) * 0.96,
                   new Symbol(relay.smartToken.symbol, 4)

--- a/src/store/modules/swap/ethBancor.ts
+++ b/src/store/modules/swap/ethBancor.ts
@@ -41,7 +41,8 @@ import {
   ViewAmountDetail,
   WeiExtendedAsset,
   PoolLiqMiningApr,
-  ProtectedLiquidity
+  ProtectedLiquidity,
+  ViewReserve
 } from "@/types/bancor";
 import { ethBancorApi } from "@/api/bancorApiWrapper";
 import {
@@ -75,7 +76,8 @@ import {
   traverseLockedBalances,
   LockedBalance,
   rewindBlocksByDays,
-  calculateProgressLevel
+  calculateProgressLevel,
+  buildPoolNameFromReserves
 } from "@/api/helpers";
 import { ContractSendMethod } from "web3-eth-contract";
 import {
@@ -3297,18 +3299,21 @@ export class EthBancorModule
 
         const { poolContainerAddress } = relay.anchor;
 
+        const reserves = relay.reserves.map(reserve => ({
+          reserveWeight: reserve.reserveWeight,
+          id: reserve.contract,
+          reserveId: poolContainerAddress + reserve.contract,
+          logo: [reserve.meta!.logo],
+          symbol: reserve.symbol,
+          contract: reserve.contract,
+          smartTokenSymbol: poolContainerAddress
+        } as ViewReserve))
+
         return {
           id: poolContainerAddress,
+          name: buildPoolNameFromReserves(reserves),
           version: Number(relay.version),
-          reserves: relay.reserves.map(reserve => ({
-            reserveWeight: reserve.reserveWeight,
-            id: reserve.contract,
-            reserveId: poolContainerAddress + reserve.contract,
-            logo: [reserve.meta!.logo],
-            symbol: reserve.symbol,
-            contract: reserve.contract,
-            smartTokenSymbol: poolContainerAddress
-          })),
+          reserves,
           fee: relay.fee / 100,
           liqDepth: relay.reserves.reduce(
             (acc, item) => acc + item.reserveFeed!.liqDepth,
@@ -3392,18 +3397,21 @@ export class EthBancorModule
           compareString(apr.poolId, relay.id)
         );
 
+        const reserves = relay.reserves.map(reserve => ({
+          id: reserve.contract,
+          reserveWeight: reserve.reserveWeight,
+          reserveId: relay.anchor.contract + reserve.contract,
+          logo: [reserve.meta!.logo],
+          symbol: reserve.symbol,
+          contract: reserve.contract,
+          smartTokenSymbol: relay.anchor.contract
+        } as ViewReserve))
+
         return {
           id: relay.anchor.contract,
+          name: buildPoolNameFromReserves(reserves),
           version: Number(relay.version),
-          reserves: relay.reserves.map(reserve => ({
-            id: reserve.contract,
-            reserveWeight: reserve.reserveWeight,
-            reserveId: relay.anchor.contract + reserve.contract,
-            logo: [reserve.meta!.logo],
-            symbol: reserve.symbol,
-            contract: reserve.contract,
-            smartTokenSymbol: relay.anchor.contract
-          })),
+          reserves,
           fee: relay.fee / 100,
           liqDepth,
           owner: relay.owner,

--- a/src/types/bancor.d.ts
+++ b/src/types/bancor.d.ts
@@ -305,6 +305,7 @@ export interface ViewGroupedPositions {
 
 export interface ViewRelay {
   id: string;
+  name: string;
   symbol: string;
   liqDepth: number;
   reserves: ViewReserve[];

--- a/src/views/Vote.vue
+++ b/src/views/Vote.vue
@@ -8,10 +8,8 @@
 import { Component } from "vue-property-decorator";
 import BaseComponent from "@/components/BaseComponent.vue";
 
-@Component({})
-export default class Vote extends BaseComponent {
-  filter: string = "";
-}
+@Component
+export default class Vote extends BaseComponent {}
 </script>
 
 <style lang="scss"></style>


### PR DESCRIPTION
addresses #721 

The application is super slow when filtering for pools or tokens or when switching from the data view to the swap view. I am assuming this must be something heavy inside the render methods happening. 

Switching from protection to vote and back is fast. I got the time taken on a roundtrip down from 15 seconds to 8 seconds on my machine which is still very slow.