### PR TITLE
dont load pools again if we already have them

### DIFF
--- a/src/components/common/PoolLogos.vue
+++ b/src/components/common/PoolLogos.vue
@@ -5,7 +5,7 @@
       class="font-w600 font-size-14 d-flex align-items-center"
       :class="[darkMode ? 'text-dark' : 'text-light', cursor ? 'cursor' : '']"
     >
-      <pool-logos-overlapped :pool-id="pool.id" size="20" />
+      <pool-logos-overlapped :pool="pool" size="20" />
       <span class="ml-2">{{ baseLabel }} </span>
       <font-awesome-icon v-if="dropdown" icon="caret-down" class="ml-2" />
       <version-badge v-if="version" :version="pool.v2 ? 2 : 1" class="ml-2" />

--- a/src/components/common/PoolLogosOverlapped.vue
+++ b/src/components/common/PoolLogosOverlapped.vue
@@ -15,6 +15,7 @@
 import { Component, Prop, Vue } from "vue-property-decorator";
 import { vxm } from "@/store/";
 import { ViewRelay } from "@/types/bancor"
+import { defaultImage } from "@/store/modules/swap/ethBancor"
 
 @Component
 export default class PoolLogosOverlapped extends Vue {
@@ -23,7 +24,23 @@ export default class PoolLogosOverlapped extends Vue {
   @Prop({ default: "32" }) size!: "16" | "20" | "32" | "48" | "96" | "128";
 
   get loadedPool() {
-    return this.pool ? this.pool : vxm.bancor.relay(this.poolId);
+    const pool = this.pool ? this.pool : vxm.bancor.relay(this.poolId);
+    if (
+      pool &&
+      pool.id &&
+      pool.reserves &&
+      pool.reserves.length >= 2 &&
+      pool.reserves[0].id &&
+      pool.reserves[1].id
+    )
+      return pool;
+    else
+      return {
+        reserves: [
+          { id: 1, logo: defaultImage },
+          { id: 2, logo: defaultImage }
+        ]
+      };
   }
 
   styleClasses(index: number) {

--- a/src/components/common/PoolLogosOverlapped.vue
+++ b/src/components/common/PoolLogosOverlapped.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <img
-      v-for="(reserve, index) in pool.reserves"
+      v-for="(reserve, index) in loadedPool.reserves"
       :key="reserve.id"
       class="img-avatar bg-white logo-shadow"
       :class="styleClasses(index)"
@@ -14,32 +14,16 @@
 <script lang="ts">
 import { Component, Prop, Vue } from "vue-property-decorator";
 import { vxm } from "@/store/";
+import { ViewRelay } from "@/types/bancor"
 
 @Component
 export default class PoolLogosOverlapped extends Vue {
-  @Prop() poolId!: string;
+  @Prop() poolId?: string;
+  @Prop() pool?: ViewRelay;
   @Prop({ default: "32" }) size!: "16" | "20" | "32" | "48" | "96" | "128";
 
-  get pool() {
-    const pool = vxm.bancor.relay(this.poolId);
-    const fallbackLogo =
-      "https://ropsten.etherscan.io/images/main/empty-token.png";
-    if (
-      pool &&
-      pool.id &&
-      pool.reserves &&
-      pool.reserves.length >= 2 &&
-      pool.reserves[0].id &&
-      pool.reserves[1].id
-    )
-      return pool;
-    else
-      return {
-        reserves: [
-          { id: 1, logo: fallbackLogo },
-          { id: 2, logo: fallbackLogo }
-        ]
-      };
+  get loadedPool() {
+    return this.pool ? this.pool : vxm.bancor.relay(this.poolId);
   }
 
   styleClasses(index: number) {

--- a/src/store/modules/swap/ethBancor.ts
+++ b/src/store/modules/swap/ethBancor.ts
@@ -867,7 +867,7 @@ const buildReserveFeedsChainlink = (
   return result;
 };
 
-const defaultImage = "https://ropsten.etherscan.io/images/main/empty-token.png";
+export const defaultImage = "https://ropsten.etherscan.io/images/main/empty-token.png";
 const ORIGIN_ADDRESS = DataTypes.originAddress;
 
 const relayShape = (converterAddress: string) => {


### PR DESCRIPTION
i did some more research on performance and found out that displaying the pool logos takes the longest time, this change made it way faster. Not sure what i broke tho maybe @pingustar can you please review?

also the default token image is set in ethBancor anyways so no need to do it twice

#721