### PR TITLE
BancorConverter - Table change `converter.v2` => `converters`

### DIFF
--- a/src/api/helpers.ts
+++ b/src/api/helpers.ts
@@ -1068,7 +1068,7 @@ export const fetchMultiRelays = async (): Promise<EosMultiRelay[]> => {
     more: boolean;
   } = await rpc.get_table_rows({
     code: contractName,
-    table: "converter.v2",
+    table: "converters",
     scope: contractName,
     limit: 99
   });


### PR DESCRIPTION
`bancorcnvrtr` contract changes table name from `converter.v2` => `converter`

Current data is currently being synced 1:1 between both tables

https://bloks.io/account/bancorcnvrtr?loadContract=true&tab=Tables&table=converters&account=bancorcnvrtr&scope=bancorcnvrtr&limit=100