### PR TITLE
disabled stake/unstake from protection (draft)

### DIFF
--- a/src/components/common/ActionButtons.vue
+++ b/src/components/common/ActionButtons.vue
@@ -1,15 +1,27 @@
 <template>
-  <div>
-    <b-btn
-      v-if="pool"
-      @click="goToPool"
-      variant="primary"
-      class="mr-3"
-      :class="small ? 'table-button-small' : 'table-button'"
-    >
-      <span v-if="!small">Add Liquidity</span>
-      <font-awesome-icon v-else icon="plus" />
-    </b-btn>
+  <div class="actionsButtons">
+    <div id="popover-target">
+      <b-btn
+        v-if="pool"
+        @click="goToPool"
+        variant="primary"
+        class="mr-3"
+        :disabled="pool.whitelisted && stakeMaintenanceMode"
+        :class="small ? 'table-button-small' : 'table-button'"
+      >
+        <span v-if="!small">Add Liquidity</span>
+        <font-awesome-icon v-else icon="plus" />
+      </b-btn>
+      <b-popover
+        v-if="stakeMaintenanceMode"
+        target="popover-target"
+        triggers="hover"
+        placement="bottom"
+      >
+        The site is undergoing maintenance and this option is not currently
+        available
+      </b-popover>
+    </div>
 
     <b-btn
       @click="goToSwap"
@@ -32,7 +44,7 @@ import { Component, Prop } from "vue-property-decorator";
 import { ViewToken, ViewRelay } from "@/types/bancor";
 import BaseComponent from "@/components/BaseComponent.vue";
 import BigNumber from "bignumber.js";
-import {vxm} from "@/store";
+import { vxm } from "@/store";
 
 @Component
 export default class ActionButtons extends BaseComponent {
@@ -41,16 +53,21 @@ export default class ActionButtons extends BaseComponent {
   @Prop({ default: false }) small!: boolean;
 
   get minNetworkTokenLiquidityforMinting() {
-    return vxm.minting.minNetworkTokenLiquidityforMinting
+    return vxm.minting.minNetworkTokenLiquidityforMinting;
+  }
+
+  get stakeMaintenanceMode() {
+    return vxm.bancor.stakeMaintenanceMode;
   }
 
   goToPool() {
-    const limit = this.minNetworkTokenLiquidityforMinting
+    const limit = this.minNetworkTokenLiquidityforMinting;
     if (
       this.pool &&
       this.pool.whitelisted &&
       this.pool.bntReserveBalance &&
-      limit !== null && limit.lt(this.pool.bntReserveBalance)
+      limit !== null &&
+      limit.lt(this.pool.bntReserveBalance)
     ) {
       this.$router.push({
         name: "AddProtectionSingle",
@@ -82,6 +99,11 @@ export default class ActionButtons extends BaseComponent {
 </script>
 
 <style lang="scss">
+.actionsButtons {
+  display: grid;
+  grid-template-columns: auto auto;
+}
+
 .table-button {
   font-size: 14px !important;
   font-weight: 500 !important;

--- a/src/components/protection/ProtectedSummary.vue
+++ b/src/components/protection/ProtectedSummary.vue
@@ -4,11 +4,28 @@
     class="rounded p-3 mb-3 block-shadow-light"
     :class="darkMode ? 'text-dark' : 'text-light'"
   >
-    <div class="d-flex justify-content-between align-items-center d-xl-none">
+    <div
+      class="d-flex justify-content-between align-items-center d-xl-none"
+      id="popover-target"
+    >
       <span class="font-size-16 font-w500">My Stake</span>
-      <b-btn variant="primary" @click="openModal" style="width: 132px">
+      <b-btn
+        variant="primary"
+        @click="openModal"
+        style="width: 132px"
+        :disabled="stakeMaintenanceMode"
+      >
         Stake
       </b-btn>
+      <b-popover
+        v-if="stakeMaintenanceMode"
+        target="popover-target"
+        triggers="hover"
+        placement="bottom"
+      >
+        The site is undergoing maintenance and this option is not currently
+        available
+      </b-popover>
     </div>
     <b-row>
       <b-col md="6" lg="3" xl="2" class="d-none d-xl-flex align-items-center">
@@ -31,10 +48,25 @@
         lg="3"
         xl="2"
         class="d-none d-xl-flex align-items-center justify-content-end"
+        id="popover-target"
       >
-        <b-btn variant="primary" class="btn-block" @click="openModal">
+        <b-btn
+          variant="primary"
+          class="btn-block"
+          @click="openModal"
+          :disabled="stakeMaintenanceMode"
+        >
           Stake
         </b-btn>
+        <b-popover
+          v-if="stakeMaintenanceMode"
+          target="popover-target"
+          triggers="hover"
+          placement="bottom"
+        >
+          The site is undergoing maintenance and this option is not currently
+          available
+        </b-popover>
       </b-col>
     </b-row>
 
@@ -59,6 +91,10 @@ export default class ProtectedSummary extends BaseComponent {
 
   get minNetworkTokenLiquidityforMinting() {
     return vxm.minting.minNetworkTokenLiquidityforMinting;
+  }
+
+  get stakeMaintenanceMode() {
+    return vxm.bancor.stakeMaintenanceMode;
   }
 
   get pools() {

--- a/src/components/protection/ProtectedTable.vue
+++ b/src/components/protection/ProtectedTable.vue
@@ -303,13 +303,17 @@
         />
       </template>
 
-      <template #cell(actions)="{ item, isCollapsable, isExpanded }">
+      <template
+        #cell(actions)="{ item, isCollapsable, isExpanded }"
+        id="popover-target"
+      >
         <b-btn
           v-if="!isCollapsable"
           @click="goToWithdraw(item.positionId)"
           :variant="darkMode ? 'outline-gray-dark' : 'outline-gray'"
           class="d-flex align-items-center justify-content-center"
           style="width: 41px; height: 41px"
+          :disabled="stakeMaintenanceMode"
         >
           <svg
             width="13"
@@ -323,6 +327,15 @@
               :fill="darkMode ? '#ffffff' : '#0A2540'"
             />
           </svg>
+          <b-popover
+            v-if="stakeMaintenanceMode"
+            target="popover-target"
+            triggers="hover"
+            placement="bottom"
+          >
+            The site is undergoing maintenance and this option is not currently
+            available
+          </b-popover>
         </b-btn>
         <div v-else>
           <b-btn
@@ -387,6 +400,7 @@ import CountdownTimer from "@/components/common/CountdownTimer.vue";
 import RemainingTime2 from "@/components/common/RemainingTime2.vue";
 import DataTable from "@/components/common/DataTable.vue";
 import BaseComponent from "@/components/BaseComponent.vue";
+import { vxm } from "@/store";
 
 @Component({
   components: {
@@ -407,6 +421,10 @@ export default class ProtectedTable extends BaseComponent {
   get groupedPositions() {
     if (this.positions.length > 0) return groupPositionsArray(this.positions);
     else return [];
+  }
+
+  get stakeMaintenanceMode() {
+    return vxm.bancor.stakeMaintenanceMode;
   }
 
   poolName(id: string): string {

--- a/src/store/modules/swap/index.ts
+++ b/src/store/modules/swap/index.ts
@@ -75,6 +75,8 @@ export class BancorModule extends VuexModule.With({
     error: false
   }));
 
+  stakeMaintenanceMode: boolean = true;
+
   slippageTolerance = 0.05;
 
   @mutation setTolerance(tolerance: number) {


### PR DESCRIPTION
Draft for issue #800 
The code for protection page is untested since Ropsten is down
The message is hard coded since I wasn't sure where are we placing global messages since locales are empty.
stakeMaintenanceMode is in the BancorModule and is currently also hard coded to true (not sure if we want it in a different module?) and needs to be connected to the network
