### PR TITLE
Split out rewards from protected positions

### DIFF
--- a/src/api/pureHelpers.ts
+++ b/src/api/pureHelpers.ts
@@ -71,20 +71,6 @@ export const groupPositionsArray = (
           .map(x => Number(x.protectedAmount ? x.protectedAmount.amount : 0))
           .reduce((sum, current) => sum + current);
 
-        let sumFullyProtectedWithReward: BigNumber;
-        if (compareString(symbol, "BNT")) {
-          sumFullyProtectedWithReward = item.pendingReserveReward.plus(
-            sumFullyProtected
-          );
-        } else {
-          const bntRewardUsd = item.pendingReserveReward.times(
-            val.bntTokenPrice
-          );
-          sumFullyProtectedWithReward = bntRewardUsd
-            .div(val.reserveTokenPrice)
-            .plus(sumFullyProtected);
-        }
-
         const sumFullyProtectedUSD =
           sumFullyProtected * val.reserveTokenPrice;
 
@@ -108,9 +94,12 @@ export const groupPositionsArray = (
           amount: sumProtectedAmount,
           usdValue: sumProtectedUSD
         };
-        item.roi =
-          (Number(sumFullyProtectedWithReward) - sumStakeAmount) /
-          sumStakeAmount;
+        item.roi = {
+          fees: sumFees / sumStakeAmount,
+          reserveRewards: item.pendingReserveReward
+            .times(val.bntTokenPrice)
+            .div(item.stake.usdValue),
+        };
         item.fees = sumFees;
 
         obj.set(id, item);

--- a/src/api/pureHelpers.ts
+++ b/src/api/pureHelpers.ts
@@ -66,19 +66,15 @@ export const groupPositionsArray = (
         const sumFullyProtected = filtered
           .map(x => Number(x.fullyProtected ? x.fullyProtected.amount : 0))
           .reduce((sum, current) => sum + current);
-        let sumFullyProtectedWithReward: BigNumber;
 
         const sumProtectedAmount = filtered
           .map(x => Number(x.protectedAmount ? x.protectedAmount.amount : 0))
           .reduce((sum, current) => sum + current);
-        let sumProtectedWithReward: BigNumber;
 
+        let sumFullyProtectedWithReward: BigNumber;
         if (compareString(symbol, "BNT")) {
           sumFullyProtectedWithReward = item.pendingReserveReward.plus(
             sumFullyProtected
-          );
-          sumProtectedWithReward = item.pendingReserveReward.plus(
-            sumProtectedAmount
           );
         } else {
           const bntRewardUsd = item.pendingReserveReward.times(
@@ -87,16 +83,13 @@ export const groupPositionsArray = (
           sumFullyProtectedWithReward = bntRewardUsd
             .div(val.reserveTokenPrice)
             .plus(sumFullyProtected);
-          sumProtectedWithReward = bntRewardUsd
-            .div(val.reserveTokenPrice)
-            .plus(sumProtectedAmount);
         }
 
-        const sumFullyProtectedWithRewardUSD =
-          Number(sumFullyProtectedWithReward) * val.reserveTokenPrice;
+        const sumFullyProtectedUSD =
+          sumFullyProtected * val.reserveTokenPrice;
 
-        const sumProtectedWithRewardUSD =
-          Number(sumProtectedWithReward) * val.reserveTokenPrice;
+        const sumProtectedUSD =
+          sumProtectedAmount * val.reserveTokenPrice;
 
         const sumFees = filtered
           .map(x => Number(x.fees ? x.fees.amount : 0))
@@ -108,12 +101,12 @@ export const groupPositionsArray = (
           unixTime: val.stake.unixTime
         };
         item.fullyProtected = {
-          amount: sumFullyProtectedWithReward.toNumber(),
-          usdValue: sumFullyProtectedWithRewardUSD
+          amount: sumFullyProtected,
+          usdValue: sumFullyProtectedUSD
         };
         item.protectedAmount = {
-          amount: sumProtectedWithReward.toNumber(),
-          usdValue: sumProtectedWithRewardUSD
+          amount: sumProtectedAmount,
+          usdValue: sumProtectedUSD
         };
         item.roi =
           (Number(sumFullyProtectedWithReward) - sumStakeAmount) /

--- a/src/components/protection/ProtectedSummary.vue
+++ b/src/components/protection/ProtectedSummary.vue
@@ -81,18 +81,15 @@ export default class ProtectedSummary extends BaseComponent {
         .map(x => Number(x.stake.usdValue || 0))
         .reduce((sum, current) => sum + current);
 
-      let protectedValue = this.positions
+      const protectedValue = this.positions
         .map(x => Number(x.fullyProtected.usdValue || 0))
         .reduce((sum, current) => sum + current);
 
-      let claimableValue = this.positions
+      const claimableValue = this.positions
         .map(x => Number(x.protectedAmount.usdValue || 0))
         .reduce((sum, current) => sum + current);
 
       const fees = protectedValue - initialStake;
-      const totalRewards = this.rewardsBalance.pendingRewards.usd.toNumber();
-      protectedValue += totalRewards;
-      claimableValue += totalRewards;
 
       return [
         {

--- a/src/components/protection/ProtectedTable.vue
+++ b/src/components/protection/ProtectedTable.vue
@@ -208,9 +208,18 @@
 
       <template #cell(roi)="{ value }">
         <div class="text-center">
+          <div>
           {{
-            typeof value !== "undefined" ? stringifyPercentage(value) : "N/A"
+              value && typeof value.fees !== "undefined" ? stringifyPercentage(value.fees) : "N/A"
           }}
+        </div>
+          <b-badge
+            v-if="value.reserveRewards.gt(0)"
+            variant="primary"
+            class="px-2"
+          >
+            + {{ stringifyPercentage(value.reserveRewards) }}
+          </b-badge>
         </div>
       </template>
       <template #cellCollapsed(roi)="{ value }">

--- a/src/types/bancor.d.ts
+++ b/src/types/bancor.d.ts
@@ -303,7 +303,10 @@ export interface ViewGroupedPositions {
     // month: number;
   };
   fees: number;
-  roi: number;
+  roi: {
+    fees: number;
+    reserveRewards: BigNumber;
+  };
   insuranceStart: number;
   coverageDecPercent: number;
   fullCoverage: number;


### PR DESCRIPTION
Recently saw a lot of people confused on Discord about the fully protected and claimable values on the "My Protected Positions" table.  (See for example this latest thread https://discord.com/channels/476133894043729930/764907781462425680/812612527103934466)

I had some issues with it myself, mostly:
* When you have multiple positions in the same pool, the sum does not add up, because on the top level the rewards are included.
* Pending rewards being shown as a part of the "My Stake" summary, while those rewards are not staked and not accruing yield.
* ROI drops after claiming fees.

This PR is my attempt at making the UI more intuitive, each topic has its separate commit and the commit messages go more in depth in the reasoning behind the change.

I am happy to contribute to this project, hope you'll consider this PR and I am of course open to feedback!