### PR TITLE
Allow case-insensitive search in pool select

### DIFF
--- a/src/components/modals/ModalSelects/ModalPoolSelect.vue
+++ b/src/components/modals/ModalSelects/ModalPoolSelect.vue
@@ -36,7 +36,7 @@ export default class ModalPoolSelect extends BaseComponent {
   currentStep = 1;
 
   get searchedPools() {
-    const searchString = this.search;
+    const searchString = this.search.toLowerCase();
     const pools = this.pools;
 
     return searchString


### PR DESCRIPTION
On my mobile phone the first letter is inevitably upper case letter, which does not have any search results.

Compare the lower case search string with the lower case symbol.
