### PR TITLE
Decimal only input using decimal keyboard

### DIFF
--- a/src/components/common/SlippageTolerance.vue
+++ b/src/components/common/SlippageTolerance.vue
@@ -9,6 +9,7 @@
       <b-input-group>
         <b-form-input
           class="text-right custom-input-field pr-1"
+          inputmode="decimal"
           :class="formInputStyles"
           v-model="custom"
           @input="setCustomSlippage"

--- a/src/components/common/TokenInputField.vue
+++ b/src/components/common/TokenInputField.vue
@@ -18,6 +18,7 @@
     <b-input-group>
       <b-form-input
         type="text"
+        inputmode="decimal"
         v-model="tokenAmount"
         style="border-right: 0 !important"
         :class="darkMode ? 'form-control-alt-dark' : 'form-control-alt-light'"


### PR DESCRIPTION
Input fields that are numeric in nature support have `inputmode="decimal"` defined to pop up the correct keyboard.

https://html.spec.whatwg.org/multipage/interaction.html#attr-inputmode


<img src="https://user-images.githubusercontent.com/2593335/110867472-c82b8c80-8294-11eb-8450-9aeacf6ff009.png" height="300">
