### PR TITLE
default child route without trailing slash

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -86,7 +86,7 @@ export const router = new Router({
       components: {
         Nav: Navigation,
         default: PageNotFound
-      }
+      },
     },
     {
       path: "/swap",
@@ -186,7 +186,7 @@ export const router = new Router({
       },
       children: [
         {
-          path: "",
+          path: "/:service/portfolio/stake",
           name: "ProtectionAction",
           component: AddProtectionHome
         },
@@ -235,7 +235,7 @@ export const router = new Router({
       props: true,
       children: [
         {
-          path: "",
+          path: "/:service/data",
           name: "Data",
           component: DataSummary,
           meta: {
@@ -254,7 +254,7 @@ export const router = new Router({
       props: true,
       children: [
         {
-          path: "",
+          path: "/:service/vote",
           name: "Vote",
           component: VotePage,
           meta: {
@@ -273,7 +273,7 @@ export const router = new Router({
       props: true,
       children: [
         {
-          path: "",
+          path: "/:service/vote-legacy",
           name: "VoteLegacy",
           component: VoteLegacy,
           meta: {
@@ -293,7 +293,7 @@ export const router = new Router({
       props: true,
       children: [
         {
-          path: "",
+          path: "/:service/fiat",
           name: "FiatPage",
           component: FiatPage,
           meta: {


### PR DESCRIPTION
Is this enough to fix https://github.com/bancorprotocol/webapp/issues/1458 ?

with below change left side-navigation redirect to pages without extra slash at the end. 
ie. when **Data** tab clicked it will redirect to **/eth/data**

